### PR TITLE
Feature/14 ユーザ登録ロジックの追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.18.0",
         "react-scripts": "5.0.1",
+        "react-toastify": "^9.1.3",
         "sass": "^1.69.5",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -5816,6 +5817,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -14641,6 +14650,18 @@
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
+      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.18.0",
     "react-scripts": "5.0.1",
+    "react-toastify": "^9.1.3",
     "sass": "^1.69.5",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { BrowserRouter } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
@@ -11,6 +12,7 @@ const root = ReactDOM.createRoot(
 root.render(
   <BrowserRouter>
     <App />
+    <ToastContainer />
   </BrowserRouter>
 );
 

--- a/src/util/notification.tsx
+++ b/src/util/notification.tsx
@@ -1,0 +1,10 @@
+import { toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
+export const errorNotification = (message: string) => {
+    return toast.error(message)
+};
+
+export const successNotification = (message: string) => {
+    return toast.success(message)
+};

--- a/src/view/signup/SignUp.tsx
+++ b/src/view/signup/SignUp.tsx
@@ -2,6 +2,8 @@ import { CSSProperties } from "react";
 import Button from "../../components/button/Button";
 import Input from "../../components/input/Input";
 import "./SignUp.scss";
+import { errorNotification, successNotification } from "../../util/notification";
+import axios from "../../util/axios";
 
 const style: CSSProperties = {
     width: "300px",
@@ -28,9 +30,41 @@ const SignUp = () => {
                 label="登録"
                 className="primary"
                 style={style}
+                onClick={ onClick }
             />
         </div>
     );
 };
+
+// TODO: フロント側のバリデーション実装
+const onClick = () => {
+    const inputElements = document.getElementsByTagName("input");
+    const elementsArray = Array.from(inputElements);
+    const elementValues: any[] = [];
+    const requestKeys = ["name", "email", "password"];
+
+    elementsArray.forEach(element => {
+        elementValues.push(element.value);
+    });
+
+    const requestData = Object.fromEntries(requestKeys.map((key, index) => [key, elementValues[index]]));
+    console.log(requestData)
+
+    axios.post("/users/register", requestData).then(
+        (response) => {
+            console.log(response.data["status"])
+            if(response.data["status"] == "error") {
+                errorNotification(response.data["message"]);
+            } else {
+                successNotification("登録に成功しました");
+                window.location.href = "/login";
+            }
+        },
+        (response) => {
+            console.log(response)
+            errorNotification("登録に失敗しました");
+        }
+    )
+}
 
 export default SignUp;


### PR DESCRIPTION
#14 
ユーザ登録画面にて、登録ボタンを押すとバックエンドにデータを送信するようになりました。
database lockedとかの都合で動かなかったりするけど、基本はこれでよいはず。
- バックエンドもフロントエンドもバリデーションをやってないので、emailの重複以外は何をやっても成功すると思います。
- 一応成功しても失敗しても通知メッセージが出るようになってます。
- 成功するとログインページに飛ばされます